### PR TITLE
SPIDR-430: v1.3.10: provide more meaningful query explanations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 *~
 *.class
+.idea
+*.swp
 
 # Package Files #
 *.jar

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>ifpress</groupId>
   <artifactId>ifpress-solr-plugin</artifactId>
-  <version>1.3.9</version>
+  <version>1.3.10</version>
   <name>ifpress solr plugin</name>
   <description>Contains plugins to be installed in the solr server</description>
   <dependencies>

--- a/src/test/java/com/ifactory/press/db/solr/search/SafariBlockJoinTest.java
+++ b/src/test/java/com/ifactory/press/db/solr/search/SafariBlockJoinTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertEquals;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.Set;
 import java.util.Map;
 
 import org.apache.lucene.search.Explanation;
@@ -63,14 +64,13 @@ public class SafariBlockJoinTest extends SolrTest {
     Map<String, String> explainMap = resp.getExplainMap();
 
     // expect to get back docs 14, 28, 42, 56, 70, 84, 98
-    HashSet<String> expectedKeys = new HashSet<String>(
+    Set<String> expectedKeys = new HashSet<String>(
       Arrays.asList("/doc/84", "/doc/56", "/doc/98", "/doc/42", "/doc/14", "/doc/70", "/doc/28")
     );
     assertEquals (expectedKeys, explainMap.keySet());
 
     ArrayList<String> explanations = new ArrayList(explainMap.values());
-    for (int i = 0; i < explanations.size(); i++) {
-      String explanation = explanations.get(i);
+    for (String explanation : explainMap.values()) {
       String[] lines = explanation.split("\n");
       assert (lines.length > 1);
     }

--- a/src/test/java/com/ifactory/press/db/solr/search/SafariBlockJoinTest.java
+++ b/src/test/java/com/ifactory/press/db/solr/search/SafariBlockJoinTest.java
@@ -3,7 +3,11 @@ package com.ifactory.press.db.solr.search;
 import static org.junit.Assert.assertEquals;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Map;
 
+import org.apache.lucene.search.Explanation;
 import org.apache.solr.client.solrj.SolrQuery;
 import org.apache.solr.client.solrj.response.QueryResponse;
 import org.apache.solr.common.SolrDocument;
@@ -13,17 +17,17 @@ import org.junit.Test;
 
 import com.ifactory.press.db.solr.SolrTest;
 
-public class SafariBlockJointest extends SolrTest {
+public class SafariBlockJoinTest extends SolrTest {
   /*
    * This test sets up 100 documents in groups of 10; each decade (0-9, 10-19, etc)
    * has the same parent, which is the highest numbered doc in that group (the one ending with 9).
-   * 
-   * Then it creates texts based on the factors of the document number so we have a rich set of 
+   *
+   * Then it creates texts based on the factors of the document number so we have a rich set of
    * multiply-occurring tokens to use for tests.
-   * 
+   *
    * The Idea of the SafariBlockJoin is to return the highest-scoring member of each group.
    */
-  
+
   @Test
   public void testDocumentSetup () throws Exception {
     SolrQuery query = new SolrQuery("*:*");
@@ -40,7 +44,7 @@ public class SafariBlockJointest extends SolrTest {
     assertEquals ("F F ", doc.get("text_t").toString());
     assertEquals ("parent", doc.get("type_s").toString());
   }
-  
+
   @Test
   public void testChildMatch () throws Exception {
     SolrQuery query = new SolrQuery("{!scoring_parent which=type_s:parent} text_t:M");
@@ -50,7 +54,28 @@ public class SafariBlockJointest extends SolrTest {
     SolrDocument doc = solr.query(query).getResults().get(0);
     assertEquals ("/doc/14", doc.get("uri").toString());
   }
-  
+
+  @Test
+  public void testChildMatchExplanation () throws Exception {
+    SolrQuery query = new SolrQuery("{!scoring_parent which=type_s:parent} text_t:M");
+    query.setShowDebugInfo(true);
+    QueryResponse resp = solr.query(query);
+    Map<String, String> explainMap = resp.getExplainMap();
+
+    // expect to get back docs 14, 28, 42, 56, 70, 84, 98
+    HashSet<String> expectedKeys = new HashSet<String>(
+      Arrays.asList("/doc/84", "/doc/56", "/doc/98", "/doc/42", "/doc/14", "/doc/70", "/doc/28")
+    );
+    assertEquals (expectedKeys, explainMap.keySet());
+
+    ArrayList<String> explanations = new ArrayList(explainMap.values());
+    for (int i = 0; i < explanations.size(); i++) {
+      String explanation = explanations.get(i);
+      String[] lines = explanation.split("\n");
+      assert (lines.length > 1);
+    }
+  }
+
   @Test
   public void testFilterQueryInteraction() throws Exception {
     SolrQuery query = new SolrQuery("{!scoring_parent which=type_s:parent} text_t:M");
@@ -68,7 +93,7 @@ public class SafariBlockJointest extends SolrTest {
     SolrDocument doc = solr.query(query).getResults().get(2);
     assertEquals ("/doc/56", doc.get("uri").toString());
   }
-  
+
   @Test
   public void testParentMatch () throws Exception {
     SolrQuery query = new SolrQuery("{!scoring_parent which=type_s:parent} text_t:R");
@@ -78,7 +103,7 @@ public class SafariBlockJointest extends SolrTest {
     SolrDocument doc = solr.query(query).getResults().get(0);
     assertEquals ("/doc/19", doc.get("uri").toString());
   }
-  
+
   @Test
   public void testGroupMatch () throws Exception {
     SolrQuery query = new SolrQuery("{!scoring_parent which=type_s:parent} text_t:A");
@@ -92,7 +117,7 @@ public class SafariBlockJointest extends SolrTest {
     assertEquals ("/doc/96", solr.query(query).getResults().get(2).get("uri").toString());
     assertEquals ("/doc/16", solr.query(query).getResults().get(3).get("uri").toString());
   }
-  
+
   @Test
   public void testParentGroupMatch () throws Exception {
     SolrQuery query = new SolrQuery("{!scoring_parent which=type_s:parent} text_t:F");
@@ -109,7 +134,7 @@ public class SafariBlockJointest extends SolrTest {
     assertEquals ("/doc/21", solr.query(query).getResults().get(4).get("uri").toString());
     assertEquals ("/doc/35", solr.query(query).getResults().get(5).get("uri").toString());
   }
-  
+
   @Test
   public void testOrphanedDocs () throws Exception {
     // create some orphans (children with no parents) and see what happens
@@ -122,24 +147,24 @@ public class SafariBlockJointest extends SolrTest {
     SolrQuery query = new SolrQuery("*:*");
     QueryResponse resp = solr.query(query);
     assertEquals (97, resp.getResults().getNumFound());
-    
+
     query = new SolrQuery("{!scoring_parent which=type_s:parent} text_t:F");
-    // expect not to get any docs back corresponding to the deleted parents 
+    // expect not to get any docs back corresponding to the deleted parents
     // since they don't satisfy the parent/child relation
     resp = solr.query(query);
     assertEquals (7, resp.getResults().getNumFound());
-    
+
     // now flush the deleted docs
     solr.optimize();
     resp = solr.query(query);
     assertEquals (7, resp.getResults().getNumFound());
   }
-  
-  @Before 
+
+  @Before
   public void setup () throws Exception {
     insertTestDocuments ();
   }
-  
+
   private void insertTestDocuments () throws Exception {
     ArrayList<SolrInputDocument> docs = new ArrayList<SolrInputDocument>();
     for (int i = 0; i < 10; i++) {


### PR DESCRIPTION
Previously, `BlockJoinWeight.explain()` only provided a very vague and not at all informative explanation:
```
5.841285E-4 = (MATCH) Score based on child doc range from 1138 to 1156.
```
Now, provides a fully detailed score explanation, including the bit from before, but also the full detail of all the internal weights/scorers:
```
5.841285E-4 = (MATCH) Score based on child doc range from 1138 to 1156.
  5.841285E-4 = (MATCH) product of:
    0.001168257 = (MATCH) sum of:
      0.001168257 = (MATCH) boost(+(heading:python^2.0 | chapter_title_unstemmed:python^30.0 | isbn:python | chapter_title:python^15.0 | publishers:python^5.0 | title_unstemmed:python^120.0 | archive_id:python | content_unstemmed:python^2.0 | title:python^120.0 | content:python | authors:python^20.0) () (),max(25.0/(3.16E-11*float(ms(const(1529683200000),date(issued)))+25.0),const(0.2))), product of:
        0.0011687248 = (MATCH) sum of:
          0.0011687248 = (MATCH) max of:
            0.0011687248 = (MATCH) weight(content_unstemmed:python^2.0 in 1145) [DefaultSimilarity], result of:
              0.0011687248 = score(doc=1145,freq=13.0 = termFreq=13.0
), product of:
                0.009217528 = queryWeight, product of:
                  2.0 = boost
                  4.501281 = idf(docFreq=37, maxDocs=1260)
                  0.0010238783 = queryNorm
                0.12679374 = fieldWeight in 1145, product of:
                  3.6055512 = tf(freq=13.0), with freq of:
                    13.0 = termFreq=13.0
                  4.501281 = idf(docFreq=37, maxDocs=1260)
                  0.0078125 = fieldNorm(doc=1145)
            5.843624E-4 = (MATCH) weight(content:python in 1145) [DefaultSimilarity], result of:
              5.843624E-4 = score(doc=1145,freq=13.0 = termFreq=13.0
), product of:
                0.004608764 = queryWeight, product of:
                  4.501281 = idf(docFreq=37, maxDocs=1260)
                  0.0010238783 = queryNorm
                0.12679374 = fieldWeight in 1145, product of:
                  3.6055512 = tf(freq=13.0), with freq of:
                    13.0 = termFreq=13.0
                  4.501281 = idf(docFreq=37, maxDocs=1260)
                  0.0078125 = fieldNorm(doc=1145)
        0.9995997 = max(25.0/(3.16E-11*float(ms(const(1529683200000),date(issued)=2018-06-19T00:00:00Z))+25.0),const(0.2))
    0.5 = coord(1/2)
```