### PR TITLE
SPIDR-916 | Upgrade plugin from Solr v4.10.2 to v5.5.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.class
 .idea
 *.swp
+*.iml
 
 # Package Files #
 *.jar

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>ifpress</groupId>
   <artifactId>ifpress-solr-plugin</artifactId>
-  <version>1.3.10</version>
+  <version>1.3.11-SNAPSHOT</version>
   <name>ifpress solr plugin</name>
   <description>Contains plugins to be installed in the solr server</description>
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <dependency>
       <groupId>org.apache.solr</groupId>
       <artifactId>solr-core</artifactId>
-      <version>4.10.2</version>
+      <version>5.5.5</version>
       <exclusions>
         <exclusion>
           <artifactId>wstx-asl</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -74,8 +74,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>2.0.2</version>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>1.7</source>
+          <target>1.7</target>
           <encoding>UTF-8</encoding>
         </configuration>
       </plugin>

--- a/solr/collection1/conf/solrconfig.xml
+++ b/solr/collection1/conf/solrconfig.xml
@@ -889,13 +889,6 @@
                   class="solr.DocumentAnalysisRequestHandler" 
                   startup="lazy" />
 
-  <!-- Admin Handlers
-
-       Admin Handlers - This will register all the standard admin
-       RequestHandlers.  
-    -->
-  <requestHandler name="/admin/" 
-                  class="solr.admin.AdminHandlers" />
 
   <!-- This single handler is equivalent to the following... -->
   <!--

--- a/solr/collection1/conf/solrconfig.xml
+++ b/solr/collection1/conf/solrconfig.xml
@@ -260,10 +260,26 @@
          uncommitted changes to the index, so use of a hard autoCommit
          is recommended (see below).
          "dir" - the target directory for transaction logs, defaults to the
-                solr data directory.  --> 
+                solr data directory.  -->
+    <!-- Not using transaction log due to issue upgrading from Solr v4_10_2 to v5_5_5:
+        https://issues.apache.org/jira/browse/SOLR-8866
+
+        TransactionLog's resolver now throws an exception (it used to just return the object) for Lucene's TextField:
+
+        org.apache.solr.common.SolrException: TransactionLog doesn't know how to
+        serialize class org.apache.lucene.document.TextField; try implementing ObjectResolver?
+
+        The ONLY way around this is to make TextField implement ObjectResolver, but TextField is a Lucene internal class.
+
+        AND we cannot create a custom class that Extends TextField (and Implements ObjectResolver)
+        because TextField is marked final (cannot create subclasses of final classes).
+
+        Hopefully more recent Solr versions fix this.
+
     <updateLog>
       <str name="dir">${solr.ulog.dir:}</str>
     </updateLog>
+    -->
 
     <!-- AutoCommit
 

--- a/solr/heron/conf/schema.xml
+++ b/solr/heron/conf/schema.xml
@@ -188,7 +188,7 @@
         <tokenizer class="solr.WhitespaceTokenizerFactory" />
         <filter class="solr.LowerCaseFilterFactory" />
         <filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0" catenateAll="0" splitOnCaseChange="1"/>
-        <filter class="solr.EdgeNGramFilterFactory" minGramSize="2" maxGramSize="15" side="front" />
+        <filter class="solr.EdgeNGramFilterFactory" minGramSize="2" maxGramSize="15" />
       </analyzer>
       <analyzer type="query">
         <tokenizer class="solr.WhitespaceTokenizerFactory" />

--- a/solr/heron/conf/solrconfig.xml
+++ b/solr/heron/conf/solrconfig.xml
@@ -316,10 +316,26 @@
          uncommitted changes to the index, so use of a hard autoCommit
          is recommended (see below).
          "dir" - the target directory for transaction logs, defaults to the
-                solr data directory.  --> 
+                solr data directory.  -->
+    <!-- Not using transaction log due to issue upgrading from Solr v4_10_2 to v5_5_5:
+        https://issues.apache.org/jira/browse/SOLR-8866
+
+        TransactionLog's resolver now throws an exception (it used to just return the object) for Lucene's TextField:
+
+        org.apache.solr.common.SolrException: TransactionLog doesn't know how to
+        serialize class org.apache.lucene.document.TextField; try implementing ObjectResolver?
+
+        The ONLY way around this is to make TextField implement ObjectResolver, but TextField is a Lucene internal class.
+
+        AND we cannot create a custom class that Extends TextField (and Implements ObjectResolver)
+        because TextField is marked final (cannot create subclasses of final classes).
+
+        Hopefully more recent Solr versions fix this.
+
     <updateLog>
       <str name="dir">${solr.ulog.dir:}</str>
     </updateLog>
+    -->
  
     <!-- AutoCommit
 

--- a/solr/heron/conf/solrconfig.xml
+++ b/solr/heron/conf/solrconfig.xml
@@ -1074,13 +1074,6 @@ unless you are sure you always want it.
                   class="solr.DocumentAnalysisRequestHandler" 
                   startup="lazy" />
 
-  <!-- Admin Handlers
-
-       Admin Handlers - This will register all the standard admin
-       RequestHandlers.  
-    -->
-  <requestHandler name="/admin/" 
-                  class="solr.admin.AdminHandlers" />
   <!-- This single handler is equivalent to the following... -->
   <!--
      <requestHandler name="/admin/luke"       class="solr.admin.LukeRequestHandler" />

--- a/src/main/java/com/ifactory/press/db/solr/HitCount.java
+++ b/src/main/java/com/ifactory/press/db/solr/HitCount.java
@@ -59,7 +59,7 @@ public class HitCount extends ValueSourceParser {
                 https://issues.apache.org/jira/browse/LUCENE-6425
              */
             IndexReader emptyReader = new MultiReader();
-            new IndexSearcher(emptyReader).createNormalizedWeight(q, false).extractTerms(terms);
+            new IndexSearcher(emptyReader).createNormalizedWeight(q, true).extractTerms(terms);
         } catch (UnsupportedOperationException e) {
             return new DoubleConstValueSource (1);
         } catch (IOException e) {

--- a/src/main/java/com/ifactory/press/db/solr/HitCount.java
+++ b/src/main/java/com/ifactory/press/db/solr/HitCount.java
@@ -19,6 +19,8 @@ package com.ifactory.press.db.solr;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.MultiReader;
@@ -45,12 +47,12 @@ public class HitCount extends ValueSourceParser {
     public ValueSource parse(FunctionQParser fp) throws SyntaxError {
         // hitcount() takes no arguments.  If we wanted to pass a query
         // we could call fp.parseNestedQuery()
-        HashSet<String> fields = new HashSet<String>(); 
+        Set<String> fields = new HashSet<String>();
         while (fp.hasMoreArguments()) {
             fields.add(fp.parseArg());
         }
         Query q = fp.subQuery(fp.getParams().get("q"), "lucene").getQuery();
-        HashSet<Term> terms = new HashSet<Term>(); 
+        Set<Term> terms = new HashSet<Term>();
         try {
             /*
                 Lucene 5.1.0 -> 5.2.0 replaced Query.extractTerms with Weight.extractTerms
@@ -65,7 +67,7 @@ public class HitCount extends ValueSourceParser {
         } catch (IOException e) {
             return new DoubleConstValueSource (1);
         }
-        ArrayList<ValueSource> termcounts = new ArrayList<ValueSource>();
+        List<ValueSource> termcounts = new ArrayList<ValueSource>(terms.size());
         for (Term t : terms) {
             if (fields.isEmpty() || fields.contains (t.field())) {
                 termcounts.add (new TermFreqValueSource(t.field(), t.text(), t.field(), t.bytes()));

--- a/src/main/java/com/ifactory/press/db/solr/analysis/PoolingAnalyzerWrapper.java
+++ b/src/main/java/com/ifactory/press/db/solr/analysis/PoolingAnalyzerWrapper.java
@@ -105,8 +105,8 @@ public final class PoolingAnalyzerWrapper extends AnalyzerWrapper {
     }
 
     protected static class TokenStreamComponentsPool {
-        private final HashMap<String, ArrayList<TokenStreamComponents>> available;
-        private final HashMap<String, ArrayList<TokenStreamComponents>> reserved;
+        private final Map<String, ArrayList<TokenStreamComponents>> available;
+        private final Map<String, ArrayList<TokenStreamComponents>> reserved;
 
         protected TokenStreamComponentsPool() {
             available = new HashMap<String, ArrayList<TokenStreamComponents>>();

--- a/src/main/java/com/ifactory/press/db/solr/processor/FieldMergingProcessor.java
+++ b/src/main/java/com/ifactory/press/db/solr/processor/FieldMergingProcessor.java
@@ -93,14 +93,16 @@ public class FieldMergingProcessor extends UpdateRequestProcessor {
                 Collection<Object> fieldValues = doc.getFieldValues(sourceFieldName);
                 if (fieldValues != null) {
                     for (Object value : fieldValues) {
-                        IndexableField fieldValue = new TextField (destinationField, fieldAnalyzer.tokenStream(sourceFieldName, value.toString()));
+                        IndexableField fieldValue = new TextField(destinationField, fieldAnalyzer.tokenStream(sourceFieldName, value.toString()));
                         doc.addField(destinationField, fieldValue);
                     }
                 }
             }
         }
         
-        if (next != null) next.processAdd(cmd);
+        if (next != null) {
+            next.processAdd(cmd);
+        }
         
         // and then release all the analyzers, readying them for re-use
         for (Map.Entry<String, PoolingAnalyzerWrapper> entry : sourceAnalyzers.entrySet()) {

--- a/src/main/java/com/ifactory/press/db/solr/processor/UpdateDocValuesProcessor.java
+++ b/src/main/java/com/ifactory/press/db/solr/processor/UpdateDocValuesProcessor.java
@@ -133,7 +133,7 @@ public class UpdateDocValuesProcessor extends UpdateRequestProcessor {
       int docID = docs.scoreDocs[0].doc;
       for (String valueField : valueFields) {
         if (doc.get(valueField) == null) {
-          NumericDocValues ndv = searcher.getAtomicReader().getNumericDocValues(valueField);
+          NumericDocValues ndv = searcher.getLeafReader().getNumericDocValues(valueField);
           if (ndv!= null) {
             long lvalue = ndv.get(docID);
             doc.addField(valueField, lvalue);

--- a/src/main/java/com/ifactory/press/db/solr/search/SafariBlockJoinQuery.java
+++ b/src/main/java/com/ifactory/press/db/solr/search/SafariBlockJoinQuery.java
@@ -6,8 +6,8 @@ import java.util.Collections;
 import java.util.Locale;
 import java.util.Set;
 
-import org.apache.lucene.index.AtomicReaderContext;
 import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.ComplexExplanation;
 import org.apache.lucene.search.DocIdSet;
@@ -104,7 +104,7 @@ public class SafariBlockJoinQuery extends Query {
 
     // NOTE: unlike Lucene's TPBJQ, acceptDocs applies to *both* child and parent documents
     @Override
-    public Scorer scorer(AtomicReaderContext readerContext, Bits acceptDocs) throws IOException {
+    public Scorer scorer(LeafReaderContext readerContext, Bits acceptDocs) throws IOException {
 
       final Scorer childScorer = childWeight.scorer(readerContext, acceptDocs);
       if (childScorer == null) {
@@ -137,7 +137,7 @@ public class SafariBlockJoinQuery extends Query {
     }
 
     @Override
-    public Explanation explain(AtomicReaderContext context, int doc) throws IOException {
+    public Explanation explain(LeafReaderContext context, int doc) throws IOException {
       Explanation childExplanation;
       Explanation baseExplanation = childWeight.explain(context, doc);
       BlockJoinScorer scorer = (BlockJoinScorer) scorer(context, context.reader().getLiveDocs());

--- a/src/main/java/com/ifactory/press/db/solr/search/SafariBlockJoinQuery.java
+++ b/src/main/java/com/ifactory/press/db/solr/search/SafariBlockJoinQuery.java
@@ -229,7 +229,7 @@ public class SafariBlockJoinQuery extends Query {
       return new TwoPhaseIterator(iterator()) {
         @Override
         public boolean matches() throws IOException {
-          return parentBits.get(parentDoc);
+          return parentDoc == -1 ? false : parentBits.get(parentDoc);
         }
 
         @Override

--- a/src/main/java/com/ifactory/press/db/solr/spelling/suggest/FirstCollector.java
+++ b/src/main/java/com/ifactory/press/db/solr/spelling/suggest/FirstCollector.java
@@ -2,17 +2,17 @@ package com.ifactory.press.db.solr.spelling.suggest;
 
 import java.io.IOException;
 
-import org.apache.lucene.index.AtomicReaderContext;
-import org.apache.lucene.search.Collector;
+import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.SimpleCollector;
 import org.apache.solr.search.EarlyTerminatingCollectorException;
 
 /** A collector to use when you know there will be no more than one match, or you don't
  * care which match you get; terminates after finding a match.
  */
-class FirstCollector extends Collector {
+class FirstCollector extends SimpleCollector {
 
-    private AtomicReaderContext arc;
+    private LeafReaderContext arc;
     
     int docID = -1;
     
@@ -31,13 +31,12 @@ class FirstCollector extends Collector {
     }
 
     @Override
-    public void setNextReader(AtomicReaderContext context) throws IOException {
+    public void doSetNextReader(LeafReaderContext context) throws IOException {
         arc = context;
     }
 
     @Override
-    public boolean acceptsDocsOutOfOrder() {
-        return true;
+    public boolean needsScores() {
+        return false;
     }
-    
 }

--- a/src/main/java/com/ifactory/press/db/solr/spelling/suggest/MultiDictionary.java
+++ b/src/main/java/com/ifactory/press/db/solr/spelling/suggest/MultiDictionary.java
@@ -156,11 +156,6 @@ public class MultiDictionary implements Dictionary {
     }
 
     @Override
-    public Comparator<BytesRef> getComparator() {
-      return curInput.getComparator();
-    }
-
-    @Override
     public BytesRef payload() {
       return curInput.payload();
     }

--- a/src/main/java/com/ifactory/press/db/solr/spelling/suggest/MultiSuggester.java
+++ b/src/main/java/com/ifactory/press/db/solr/spelling/suggest/MultiSuggester.java
@@ -18,6 +18,7 @@ import org.apache.lucene.document.Document;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.spell.HighFrequencyDictionary;
 import org.apache.lucene.search.suggest.analyzing.AnalyzingInfixSuggester;
+import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefBuilder;
 import org.apache.solr.common.SolrInputDocument;
 import org.apache.solr.common.util.NamedList;
@@ -412,7 +413,9 @@ public class MultiSuggester extends Suggester {
       // commit
       ConcurrentHashMap<String, Integer> batch = fld.pending;
       fld.pending = new ConcurrentHashMap<String, Integer>(batch.size());
+      BytesRef bytes = new BytesRef(maxSuggestionLength);
       BytesRefBuilder bytesRefBuilder = new BytesRefBuilder();  // From Lucene docs: BytesRef should not be used as a buffer, use BytesRefBuilder instead
+      bytesRefBuilder.append(bytes);
       Term t = new Term(fld.fieldName, bytesRefBuilder);
       long minCount = (long) (fld.minFreq * docCount);
       long maxCount = (long) (docCount <= 1 ? Long.MAX_VALUE : (fld.maxFreq * docCount + 1));
@@ -443,8 +446,8 @@ public class MultiSuggester extends Suggester {
           }
         }
         bytesRefBuilder.copyChars(term);
-        // LOG.debug("add " + bytes.utf8ToString());
-        ais.update(bytesRefBuilder.toBytesRef(), weight);
+        bytes = bytesRefBuilder.get();
+        ais.update(bytes, weight);
       }
     }
     // refresh after each field so the counts will accumulate across fields?

--- a/src/main/java/com/ifactory/press/db/solr/spelling/suggest/MultiSuggester.java
+++ b/src/main/java/com/ifactory/press/db/solr/spelling/suggest/MultiSuggester.java
@@ -3,10 +3,7 @@ package com.ifactory.press.db.solr.spelling.suggest;
 import java.io.Closeable;
 import java.io.IOException;
 import java.text.BreakIterator;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.lucene.analysis.Analyzer;
@@ -262,7 +259,7 @@ public class MultiSuggester extends Suggester {
       throw new IllegalStateException("not supported: analyzing stored fields");
     }
     LOG.info(String.format("build suggestions from values for: %s (%d)", fld.fieldName, fld.weight));
-    HashSet<String> fieldsToLoad = new HashSet<String>();
+    Set<String> fieldsToLoad = new HashSet<String>();
     fieldsToLoad.add(fld.fieldName);
     int maxDoc = searcher.maxDoc();
     for (int idoc = 0; idoc < maxDoc; ++idoc) {
@@ -372,7 +369,7 @@ public class MultiSuggester extends Suggester {
     TokenStream tokens = fld.fieldAnalyzer.tokenStream(fld.fieldName, value);
     tokens.reset();
     CharTermAttribute termAtt = tokens.addAttribute(CharTermAttribute.class);
-    HashSet<String> once = new HashSet<String>();
+    Set<String> once = new HashSet<String>();
     try {
       while (tokens.incrementToken()) {
         String token = termAtt.toString();

--- a/src/main/java/com/ifactory/press/db/solr/spelling/suggest/MultiSuggester.java
+++ b/src/main/java/com/ifactory/press/db/solr/spelling/suggest/MultiSuggester.java
@@ -18,7 +18,7 @@ import org.apache.lucene.document.Document;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.spell.HighFrequencyDictionary;
 import org.apache.lucene.search.suggest.analyzing.AnalyzingInfixSuggester;
-import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.BytesRefBuilder;
 import org.apache.solr.common.SolrInputDocument;
 import org.apache.solr.common.util.NamedList;
 import org.apache.solr.core.CloseHook;
@@ -412,8 +412,8 @@ public class MultiSuggester extends Suggester {
       // commit
       ConcurrentHashMap<String, Integer> batch = fld.pending;
       fld.pending = new ConcurrentHashMap<String, Integer>(batch.size());
-      BytesRef bytes = new BytesRef(maxSuggestionLength);
-      Term t = new Term(fld.fieldName, bytes);
+      BytesRefBuilder bytesRefBuilder = new BytesRefBuilder();  // From Lucene docs: BytesRef should not be used as a buffer, use BytesRefBuilder instead
+      Term t = new Term(fld.fieldName, bytesRefBuilder);
       long minCount = (long) (fld.minFreq * docCount);
       long maxCount = (long) (docCount <= 1 ? Long.MAX_VALUE : (fld.maxFreq * docCount + 1));
       updated = updated || !batch.isEmpty();
@@ -442,9 +442,9 @@ public class MultiSuggester extends Suggester {
             weight = (fld.weight * count) / docCount;
           }
         }
-        bytes.copyChars(term);
+        bytesRefBuilder.copyChars(term);
         // LOG.debug("add " + bytes.utf8ToString());
-        ais.update(bytes, weight);
+        ais.update(bytesRefBuilder.toBytesRef(), weight);
       }
     }
     // refresh after each field so the counts will accumulate across fields?

--- a/src/main/java/com/ifactory/press/db/solr/spelling/suggest/SafariInfixSuggester.java
+++ b/src/main/java/com/ifactory/press/db/solr/spelling/suggest/SafariInfixSuggester.java
@@ -26,14 +26,13 @@ public class SafariInfixSuggester extends AnalyzingInfixSuggester {
   private Set<BytesRef> showContext, hideContext;
 
   public SafariInfixSuggester(
-          Version matchVersion,
           Directory dir,
           Analyzer indexAnalyzer,
           Analyzer queryAnalyzer,
           int minPrefixChars,
           boolean highlight
   ) throws IOException {
-    super(matchVersion, dir, indexAnalyzer, queryAnalyzer, minPrefixChars, false);
+    super(dir, indexAnalyzer, queryAnalyzer, minPrefixChars, true);
     this.highlight = highlight;
 
     showContext = Collections.singleton(new BytesRef(new byte[] { (byte) Context.SHOW.ordinal() }));

--- a/src/main/java/com/ifactory/press/db/solr/spelling/suggest/SafariInfixSuggester.java
+++ b/src/main/java/com/ifactory/press/db/solr/spelling/suggest/SafariInfixSuggester.java
@@ -25,9 +25,15 @@ public class SafariInfixSuggester extends AnalyzingInfixSuggester {
 
   private Set<BytesRef> showContext, hideContext;
 
-  public SafariInfixSuggester(Version matchVersion, Directory dir, Analyzer indexAnalyzer, Analyzer queryAnalyzer,
-      int minPrefixChars, boolean highlight) throws IOException {
-    super(matchVersion, dir, indexAnalyzer, queryAnalyzer, minPrefixChars);
+  public SafariInfixSuggester(
+          Version matchVersion,
+          Directory dir,
+          Analyzer indexAnalyzer,
+          Analyzer queryAnalyzer,
+          int minPrefixChars,
+          boolean highlight
+  ) throws IOException {
+    super(matchVersion, dir, indexAnalyzer, queryAnalyzer, minPrefixChars, false);
     this.highlight = highlight;
 
     showContext = Collections.singleton(new BytesRef(new byte[] { (byte) Context.SHOW.ordinal() }));
@@ -82,11 +88,6 @@ public class SafariInfixSuggester extends AnalyzingInfixSuggester {
 
     @Override
     public BytesRef next() throws IOException {
-      return null;
-    }
-
-    @Override
-    public Comparator<BytesRef> getComparator() {
       return null;
     }
 

--- a/src/main/java/com/ifactory/press/db/solr/spelling/suggest/SafeInfixLookupFactory.java
+++ b/src/main/java/com/ifactory/press/db/solr/spelling/suggest/SafeInfixLookupFactory.java
@@ -60,7 +60,7 @@ public class SafeInfixLookupFactory extends AnalyzingInfixLookupFactory {
 
          try {
              return new SafariInfixSuggester(core.getSolrConfig().luceneMatchVersion, 
-                                           FSDirectory.open(new File(indexPath)), indexAnalyzer,
+                                           FSDirectory.open(new File(indexPath).toPath()), indexAnalyzer,
                                            queryAnalyzer, minPrefixChars, highlight);
          } catch (IOException e) {
              throw new SolrException(ErrorCode.SERVER_ERROR, e);

--- a/src/main/java/com/ifactory/press/db/solr/spelling/suggest/SafeInfixLookupFactory.java
+++ b/src/main/java/com/ifactory/press/db/solr/spelling/suggest/SafeInfixLookupFactory.java
@@ -59,8 +59,7 @@ public class SafeInfixLookupFactory extends AnalyzingInfixLookupFactory {
         }
 
          try {
-             return new SafariInfixSuggester(core.getSolrConfig().luceneMatchVersion, 
-                                           FSDirectory.open(new File(indexPath).toPath()), indexAnalyzer,
+             return new SafariInfixSuggester(FSDirectory.open(new File(indexPath).toPath()), indexAnalyzer,
                                            queryAnalyzer, minPrefixChars, highlight);
          } catch (IOException e) {
              throw new SolrException(ErrorCode.SERVER_ERROR, e);

--- a/src/test/java/com/ifactory/press/db/solr/HeronSolrTest.java
+++ b/src/test/java/com/ifactory/press/db/solr/HeronSolrTest.java
@@ -2,7 +2,7 @@ package com.ifactory.press.db.solr;
 
 import java.io.IOException;
 
-import org.apache.solr.client.solrj.SolrServer;
+import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.embedded.EmbeddedSolrServer;
 import org.apache.solr.core.CoreContainer;
@@ -13,7 +13,7 @@ import org.junit.Before;
 public class HeronSolrTest {
 
     static CoreContainer coreContainer;
-    protected SolrServer solr;
+    protected SolrClient solr;
 
     @Before
     public void startup() throws IOException, SolrServerException {

--- a/src/test/java/com/ifactory/press/db/solr/SolrTest.java
+++ b/src/test/java/com/ifactory/press/db/solr/SolrTest.java
@@ -4,7 +4,7 @@ import java.io.File;
 import java.io.IOException;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.solr.client.solrj.SolrServer;
+import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.embedded.EmbeddedSolrServer;
 import org.apache.solr.core.CoreContainer;
@@ -17,7 +17,7 @@ import org.junit.BeforeClass;
 public class SolrTest {
 
   static CoreContainer coreContainer;
-  protected SolrServer solr;
+  protected SolrClient solr;
 
     @BeforeClass
     public static void startup() throws Exception {

--- a/src/test/java/com/ifactory/press/db/solr/highlight/PostingsHighlighterTest.java
+++ b/src/test/java/com/ifactory/press/db/solr/highlight/PostingsHighlighterTest.java
@@ -31,7 +31,7 @@ import org.apache.lucene.document.FieldType;
 import org.apache.lucene.document.StringField;
 import org.apache.lucene.document.TextField;
 import org.apache.lucene.index.DirectoryReader;
-import org.apache.lucene.index.FieldInfo.IndexOptions;
+import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.Term;
@@ -41,21 +41,18 @@ import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.postingshighlight.PostingsHighlighter;
 import org.apache.lucene.store.RAMDirectory;
-import org.apache.lucene.util.Version;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
 public class PostingsHighlighterTest {
-  
-  private static final Version VERSION = Version.LATEST;
 
   private IndexWriter iw;
   
   @Before
   public void startup() throws IOException {
     RAMDirectory dir = new RAMDirectory();
-    IndexWriterConfig iwc = new IndexWriterConfig(VERSION, new SafariAnalyzer(true));
+    IndexWriterConfig iwc = new IndexWriterConfig(new SafariAnalyzer(true));
     iw = new IndexWriter(dir, iwc);
   }
   
@@ -99,8 +96,8 @@ public class PostingsHighlighterTest {
   class SynonymAnalyzer extends Analyzer {
 
     @Override
-    protected TokenStreamComponents createComponents(String fieldName, Reader reader) {
-      Tokenizer tokenizer = new WhitespaceTokenizer(reader);
+    protected TokenStreamComponents createComponents(String fieldName) {
+      Tokenizer tokenizer = new WhitespaceTokenizer();
       TokenFilter filter = new LowerCaseFilter(tokenizer);
       return new TokenStreamComponents(tokenizer, filter);
     }
@@ -115,12 +112,8 @@ public class PostingsHighlighterTest {
     }
 
     @Override
-    protected TokenStreamComponents createComponents(String fieldName, Reader reader) {
-      CharFilter charFilter = new HTMLStripCharFilter(reader);
-      Pattern pat1 = Pattern.compile("([A-Za-z])\\+\\+");
-      charFilter = new PatternReplaceCharFilter(pat1, "$1plusplus", charFilter);
-      charFilter = new PatternReplaceCharFilter(Pattern.compile("([A-Za-z])\\#"), "$1sharp", charFilter);
-      Tokenizer tokenizer = new WhitespaceTokenizer(charFilter);
+    protected TokenStreamComponents createComponents(String fieldName) {
+      Tokenizer tokenizer = new WhitespaceTokenizer();
       // TODO protwords.txt
       TokenFilter filter = new WordDelimiterFilter(tokenizer, 
           GENERATE_WORD_PARTS |
@@ -151,7 +144,6 @@ public class PostingsHighlighterTest {
         throw new RuntimeException ("failed to read synonyms", e);
       }
     }
-    
   }
 
 }

--- a/src/test/java/com/ifactory/press/db/solr/highlight/SolrPostingsHighlighterTest.java
+++ b/src/test/java/com/ifactory/press/db/solr/highlight/SolrPostingsHighlighterTest.java
@@ -40,7 +40,7 @@ public class SolrPostingsHighlighterTest extends HeronSolrTest {
   // TODO - randomized testing -- search for phrases and/or words drawn from sentences and
   // expect those same sentences to be returned.
   
-  private void assertSnippet (String q, String expectedSnippet) throws SolrServerException {
+  private void assertSnippet (String q, String expectedSnippet) throws SolrServerException, IOException {
     SolrQuery query = new SolrQuery(q);
     query.setHighlight(true);
     query.set("hl.tag.pre", "<b>");

--- a/src/test/java/com/ifactory/press/db/solr/processor/FieldMergingProcessorTest.java
+++ b/src/test/java/com/ifactory/press/db/solr/processor/FieldMergingProcessorTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -92,7 +93,7 @@ public class FieldMergingProcessorTest extends SolrTest {
         assertTrue ("title not found in catchall terms list", found);
     }
     
-    private void assertQueryCount (int count, String query) throws SolrServerException {
+    private void assertQueryCount (int count, String query) throws SolrServerException, IOException {
         SolrQuery solrQuery = new SolrQuery (query);
         QueryResponse resp = solr.query(solrQuery);
         SolrDocumentList docs = resp.getResults();
@@ -100,7 +101,7 @@ public class FieldMergingProcessorTest extends SolrTest {
         
     }
     
-    private List<TermsResponse.Term> getTerms (String field) throws SolrServerException {
+    private List<TermsResponse.Term> getTerms (String field) throws SolrServerException, IOException {
         SolrQuery solrQuery = new SolrQuery();
         solrQuery.setParam(CommonParams.QT, "/terms");
         solrQuery.setParam(TermsParams.TERMS, true);

--- a/src/test/java/com/ifactory/press/db/solr/processor/UpdateDocValuesTest.java
+++ b/src/test/java/com/ifactory/press/db/solr/processor/UpdateDocValuesTest.java
@@ -30,6 +30,8 @@ import org.junit.Test;
 
 import com.ifactory.press.db.solr.SolrTest;
 
+import java.io.IOException;
+
 
 public class UpdateDocValuesTest extends SolrTest {
     
@@ -102,7 +104,7 @@ public class UpdateDocValuesTest extends SolrTest {
       assertEquals (0, docs.get(0).getFirstValue(dvFieldFunction));
     }
 
-    private void assertDocValues(int n) throws SolrServerException {
+    private void assertDocValues(int n) throws SolrServerException, IOException {
       SolrQuery query = new SolrQuery ("*:*");
       
       query.setSort(WEIGHT_DV, ORDER.desc);
@@ -112,7 +114,7 @@ public class UpdateDocValuesTest extends SolrTest {
       assertEquals (uri(n), getFirstUri(query));
     }
 
-    private void assertDocValue(String uri, Integer dv) throws SolrServerException {
+    private void assertDocValue(String uri, Integer dv) throws SolrServerException, IOException {
       final SolrQuery query = new SolrQuery (String.format("%s:\"%s\"", URI, uri));
       final String weightField = String.format("field(%s)", WEIGHT_DV);
       query.setFields(URI, weightField);
@@ -130,7 +132,7 @@ public class UpdateDocValuesTest extends SolrTest {
       return "/doc:" + n + ":x/" + k;
     }
     
-    private void assertNoDocValues() throws SolrServerException {
+    private void assertNoDocValues() throws SolrServerException, IOException {
       SolrQuery query = new SolrQuery ("*:*");
 
       String firstUri = getFirstUri(query);      
@@ -144,7 +146,7 @@ public class UpdateDocValuesTest extends SolrTest {
       assertEquals (firstUri, getFirstUri(query));
     }
 
-    private String getFirstUri (SolrQuery query) throws SolrServerException {
+    private String getFirstUri (SolrQuery query) throws SolrServerException, IOException {
       QueryResponse resp = solr.query(query);
       SolrDocumentList docs = resp.getResults();
       return (String) docs.get(0).getFirstValue(URI);

--- a/src/test/java/com/ifactory/press/db/solr/search/SafariBlockJoinTest.java
+++ b/src/test/java/com/ifactory/press/db/solr/search/SafariBlockJoinTest.java
@@ -2,11 +2,7 @@ package com.ifactory.press.db.solr.search;
 
 import static org.junit.Assert.assertEquals;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
-import java.util.Map;
+import java.util.*;
 
 import org.apache.solr.client.solrj.SolrQuery;
 import org.apache.solr.client.solrj.response.QueryResponse;
@@ -174,7 +170,7 @@ public class SafariBlockJoinTest extends SolrTest {
   }
 
   private void insertTestDocuments () throws Exception {
-    ArrayList<SolrInputDocument> docs = new ArrayList<SolrInputDocument>();
+    List<SolrInputDocument> docs = new ArrayList<SolrInputDocument>();
     for (int i = 0; i < 10; i++) {
       for (int j = 0; j < 10; j++) {
           SolrInputDocument doc = new SolrInputDocument();

--- a/src/test/java/com/ifactory/press/db/solr/spelling/suggest/MultiSuggesterTest.java
+++ b/src/test/java/com/ifactory/press/db/solr/spelling/suggest/MultiSuggesterTest.java
@@ -105,7 +105,7 @@ public class MultiSuggesterTest extends SolrTest {
     reload.process(solr);
   }
 
-  private Suggestion assertSuggestionCount(String prefix, int count, String suggester) throws SolrServerException {
+  private Suggestion assertSuggestionCount(String prefix, int count, String suggester) throws SolrServerException, IOException {
     SolrQuery q = new SolrQuery(prefix);
     q.setRequestHandler("/suggest/" + suggester);
     q.set("spellcheck.count", 100);
@@ -123,12 +123,12 @@ public class MultiSuggesterTest extends SolrTest {
     return suggestion;
   }
 
-  private void assertNoSuggestions() throws SolrServerException {
+  private void assertNoSuggestions() throws SolrServerException, IOException {
     assertSuggestionCount("t", 0, "all");   
     assertSuggestionCount("a", 0, "title");   
   }
   
-  private void assertSuggestions() throws SolrServerException {
+  private void assertSuggestions() throws SolrServerException, IOException {
     Suggestion suggestion = assertSuggestionCount("t", 8, "all");   
     // TITLE occurs once in a high-weighted field; t1-t4, etc each occur twice, t5 once, their/time occur once
     // 'the' and 'to' occur too many times and get excluded
@@ -171,7 +171,7 @@ public class MultiSuggesterTest extends SolrTest {
     }
   }
 
-  private QueryResponse rebuildSuggester() throws SolrServerException {
+  private QueryResponse rebuildSuggester() throws SolrServerException, IOException {
     SolrQuery q = new SolrQuery("t");
     q.setRequestHandler("/suggest/title");
     q.set("spellcheck.build", "true");


### PR DESCRIPTION
Upgrade to support Solr v5.5.5. There's some notes in the official changelog (http://lucene.apache.org/solr/5_5_5/changes/Changes.html) although a lot of major changes were not documented (like reworking `acceptDocs` and completely changing class inheritance of FixedBitSet and other related classes to prepare for removing Filter).

Biggest changes are in SafariBlockJoinQuery and ScoringParentQParser, our block join relied on a lot of Lucene internal classes being changed/deprecated.

Ticket 1/3 of getting this plugin to be compatible with Solr v7.6 :smiley:

![finally](https://user-images.githubusercontent.com/6943384/54943813-7b641500-4f08-11e9-964a-bf81b8a03c33.gif)
