### PR TITLE
SPIDR-918 | SOLR 7.6.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,11 +1,13 @@
 ifpress-solr-plugin CHANGELOG
 =============================
 * 1.6.0
+
   - Upgrade to Solr v7.6.0
   - SOLR-10700: PostingsHighlighter and its related classes (deprecated) replaced with the suggested UnifiedHighlighter.
-    - UnifiedHighlighterTest: UnifiedHighlighter object creation requires an IndexAnalyzer, using SafariAnalyzer.
-    - SolrUnifiedHighlighterTest: Unlike Postings, UnifiedHighlighter unifies matching sentences near each other, despite
-    the SENTENCE break type. It relies on 'fragsize' to determine to return multiple sentences of just the highest matching sentence.
+      - UnifiedHighlighter has options to work almost exactly like PostingsHighlighter did, as Unified was a more performant extension of Postings.
+      - UnifiedHighlighterTest: UnifiedHighlighter object creation requires an IndexAnalyzer, using SafariAnalyzer.
+      - SolrUnifiedHighlighterTest: Unlike Postings, UnifiedHighlighter unifies matching sentences near each other, despite
+        the SENTENCE break type. It relies on 'fragsize' to determine to return multiple sentences of just the highest matching sentence.
   - LUCENE-7867: analysis.Token (deprecated in Solr 2) moved to solr.spelling as that should be the only place it is used.
   - UpdateDocValuesProcessor: LUCENE-7407, NumericDocValues uses an iterator, must call iterator method advanceExact to iterate to desired doc value.
   - SafariQueryParserTest:
@@ -62,12 +64,15 @@ ifpress-solr-plugin CHANGELOG
     - A custom TwoPhaseIterator needed for filtering
     - Uses getLiveDocs() to check for deleted docs since acceptDocs can no longer be used.
   - SafariBlockJoinTest.java: Small issue with filter query on block join, not sure if even possible to resolve.
-  SBJQ used to check 'acceptDocs' to make sure parent doc was not deleted or filtered out.
-  Lucene v5.3.0 includes a huge rework on 'acceptDocs' for LUCENE-6553, removing 'acceptDocs' from Weight class.
-  SBJQ no longer has access to 'acceptDocs'. It was forced to use reader.getLiveDocs() instead to make sure the parent
-  docs were not deleted.
-  Because of this, SBJQ can filter out children of deleted parent docs (see testOrphanedDocs) but does not filter out
-  children of parents who do not meet filter query criteria.
+    SBJQ used to check 'acceptDocs' to make sure parent doc was not deleted or filtered out.
+
+    Lucene v5.3.0 includes a huge rework on 'acceptDocs' for LUCENE-6553, removing 'acceptDocs' from Weight class.
+
+    SBJQ no longer has access to 'acceptDocs'. It was forced to use reader.getLiveDocs() instead to make sure the parent
+    docs were not deleted.
+
+    Because of this, SBJQ can filter out children of deleted parent docs (see testOrphanedDocs) but does not filter out
+    children of parents who do not meet filter query criteria.
 
 
 * 1.3.10

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,19 @@
 ifpress-solr-plugin CHANGELOG
-==================
+=============================
+* 1.6.0
+  - Upgrade to Solr v7.6.0
+  - SOLR-10700: PostingsHighlighter and its related classes (deprecated) replaced with the suggested UnifiedHighlighter.
+    - UnifiedHighlighterTest: UnifiedHighlighter object creation requires an IndexAnalyzer, using SafariAnalyzer.
+    - SolrUnifiedHighlighterTest: Unlike Postings, UnifiedHighlighter unifies matching sentences near each other, despite
+    the SENTENCE break type. It relies on 'fragsize' to determine to return multiple sentences of just the highest matching sentence.
+  - LUCENE-7867: analysis.Token (deprecated in Solr 2) moved to solr.spelling as that should be the only place it is used.
+  - UpdateDocValuesProcessor: LUCENE-7407, NumericDocValues uses an iterator, must call iterator method advanceExact to iterate to desired doc value.
+  - SafariQueryParserTest:
+    - Single clause BooleanQueries no longer wrapped with an additional Occur.MUST
+    - LUCENE-7369: BooleanQuery's disableCoords field was removed
+  - SOLR-10585: defaultSearchField (deprecated in Solr 3) removed from schema use, using 'df' instead.
+  - SOLR-10584: Setting <solrQueryParser defaultOperator="..."/> in schema now causes an exception, must use suggested "q.op" parameter on the request instead
+
 * 1.5.0
 
   - Upgrade to Solr v6.6.5

--- a/pom.xml
+++ b/pom.xml
@@ -2,14 +2,14 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>ifpress</groupId>
   <artifactId>ifpress-solr-plugin</artifactId>
-  <version>1.5.0</version>
+  <version>1.6.0</version>
   <name>ifpress solr plugin</name>
   <description>Contains plugins to be installed in the solr server</description>
   <dependencies>
     <dependency>
       <groupId>org.apache.solr</groupId>
       <artifactId>solr-core</artifactId>
-      <version>6.6.5</version>
+      <version>7.6.0</version>
       <exclusions>
         <exclusion>
           <artifactId>wstx-asl</artifactId>

--- a/solr/collection1/conf/schema.xml
+++ b/solr/collection1/conf/schema.xml
@@ -442,9 +442,6 @@
     field is marked with required="false", it will be a required field -->
   <uniqueKey>uri</uniqueKey>
 
-  <!-- field for the QueryParser to use when an explicit fieldname is absent -->
-  <defaultSearchField>xml_text</defaultSearchField>
-
   <!-- SolrQueryParser configuration: defaultOperator="AND|OR" -->
   <solrQueryParser defaultOperator="AND" />
 

--- a/solr/collection1/conf/schema.xml
+++ b/solr/collection1/conf/schema.xml
@@ -442,9 +442,6 @@
     field is marked with required="false", it will be a required field -->
   <uniqueKey>uri</uniqueKey>
 
-  <!-- SolrQueryParser configuration: defaultOperator="AND|OR" -->
-  <solrQueryParser defaultOperator="AND" />
-
   <!-- Lazy field loading will attempt to read only parts of documents on 
     disk that are requested. Enabling should be faster if you aren't retrieving 
     all stored fields. -->

--- a/solr/collection1/conf/solrconfig.xml
+++ b/solr/collection1/conf/solrconfig.xml
@@ -712,6 +712,7 @@
       -->
      <lst name="defaults">
        <str name="echoParams">explicit</str>
+       <str name="df">xml_text</str>
        <int name="rows">10</int>
        <!--<str name="df">text</str>-->
      </lst>
@@ -1187,8 +1188,8 @@
 
        http://wiki.apache.org/solr/HighlightingParameters
     -->
-  <searchComponent class="solr.HighlightComponent" name="highlight-postings">
-    <highlighting class="org.apache.solr.highlight.PostingsSolrHighlighter"/>
+  <searchComponent class="solr.HighlightComponent" name="highlight-unified">
+    <highlighting class="org.apache.solr.highlight.UnifiedSolrHighlighter"/>
   </searchComponent>
 
   <searchComponent class="solr.HighlightComponent" name="highlight">

--- a/solr/heron/conf/schema.xml
+++ b/solr/heron/conf/schema.xml
@@ -253,8 +253,4 @@
 
   <!-- field to use to determine and enforce document uniqueness. -->
   <uniqueKey>id</uniqueKey>
-
-  <!-- SolrQueryParser configuration: defaultOperator="AND|OR" -->
-  <solrQueryParser defaultOperator="OR"/>
-
 </schema>

--- a/solr/heron/conf/schema.xml
+++ b/solr/heron/conf/schema.xml
@@ -254,9 +254,6 @@
   <!-- field to use to determine and enforce document uniqueness. -->
   <uniqueKey>id</uniqueKey>
 
-  <!-- field for the QueryParser to use when an explicit fieldname is absent -->
-  <defaultSearchField>text</defaultSearchField>
-
   <!-- SolrQueryParser configuration: defaultOperator="AND|OR" -->
   <solrQueryParser defaultOperator="OR"/>
 

--- a/solr/heron/conf/solrconfig.xml
+++ b/solr/heron/conf/solrconfig.xml
@@ -809,6 +809,7 @@
     <lst name="defaults">
       <str name="defType">edismax</str>
       <str name="echoParams">all</str>
+      <str name="df">text</str>
       <int name="rows">10</int>
       <str name="q.op">OR</str>
       <str name="qf">chapter_title^10 text^1</str>

--- a/src/main/java/com/ifactory/press/db/solr/highlight/HighlightFormatter.java
+++ b/src/main/java/com/ifactory/press/db/solr/highlight/HighlightFormatter.java
@@ -3,8 +3,8 @@ package com.ifactory.press.db.solr.highlight;
 import java.util.Arrays;
 import java.util.Comparator;
 
-import org.apache.lucene.search.postingshighlight.DefaultPassageFormatter;
-import org.apache.lucene.search.postingshighlight.Passage;
+import org.apache.lucene.search.uhighlight.DefaultPassageFormatter;
+import org.apache.lucene.search.uhighlight.Passage;
 
 public class HighlightFormatter extends DefaultPassageFormatter {
   

--- a/src/main/java/com/ifactory/press/db/solr/highlight/SafariSolrHighlighter.java
+++ b/src/main/java/com/ifactory/press/db/solr/highlight/SafariSolrHighlighter.java
@@ -1,24 +1,24 @@
 package com.ifactory.press.db.solr.highlight;
 
-import org.apache.lucene.search.postingshighlight.PassageFormatter;
-import org.apache.lucene.search.postingshighlight.PassageScorer;
-import org.apache.lucene.search.postingshighlight.PostingsHighlighter;
+import org.apache.lucene.search.uhighlight.PassageFormatter;
+import org.apache.lucene.search.uhighlight.PassageScorer;
+import org.apache.lucene.search.uhighlight.UnifiedHighlighter;
 import org.apache.solr.common.params.HighlightParams;
-import org.apache.solr.highlight.PostingsSolrHighlighter;
+import org.apache.solr.highlight.UnifiedSolrHighlighter;
 import org.apache.solr.request.SolrQueryRequest;
 
-public class SafariSolrHighlighter extends PostingsSolrHighlighter {
+public class SafariSolrHighlighter extends UnifiedSolrHighlighter {
 
   /** Creates an instance of the Lucene PostingsHighlighter. Provided for subclass extension so that
-   * a subclass can return a subclass of {@link PostingsSolrHighlighter.SolrExtendedPostingsHighlighter}. */
+   * a subclass can return a subclass of {@link UnifiedSolrHighlighter.SolrExtendedUnifiedHighlighter}. */
   @Override
-  protected PostingsHighlighter getHighlighter(SolrQueryRequest req) {
-    return new SafariPostingsHighlighter(req);
+  protected UnifiedHighlighter getHighlighter(SolrQueryRequest req) {
+    return new SafariUnifiedHighlighter(req);
   }
 
-  public class SafariPostingsHighlighter extends SolrExtendedPostingsHighlighter {
+  public class SafariUnifiedHighlighter extends SolrExtendedUnifiedHighlighter {
 
-    public SafariPostingsHighlighter(SolrQueryRequest req) {
+    public SafariUnifiedHighlighter(SolrQueryRequest req) {
       super(req);
     }
         

--- a/src/main/java/com/ifactory/press/db/solr/processor/UpdateDocValuesProcessor.java
+++ b/src/main/java/com/ifactory/press/db/solr/processor/UpdateDocValuesProcessor.java
@@ -135,8 +135,10 @@ public class UpdateDocValuesProcessor extends UpdateRequestProcessor {
       for (String valueField : valueFields) {
         if (doc.get(valueField) == null) {
           NumericDocValues ndv = leafReader.getNumericDocValues(valueField);
-          if (ndv!= null) {
-            long lvalue = ndv.get(docID);
+          if (ndv !=  null) {
+            // LUCENE-7404 made major change forcing doc values to be retrieved through an iterator
+            ndv.advanceExact(docID);
+            long lvalue = ndv.longValue();
             doc.addField(valueField, lvalue);
             // LOG.debug("retrieved doc value %d", lvalue);
           } else {

--- a/src/main/java/com/ifactory/press/db/solr/spelling/suggest/MultiSuggester.java
+++ b/src/main/java/com/ifactory/press/db/solr/spelling/suggest/MultiSuggester.java
@@ -7,7 +7,7 @@ import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.lucene.analysis.Analyzer;
-import org.apache.lucene.analysis.Token;
+import org.apache.solr.spelling.Token;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.core.KeywordAnalyzer;
 import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;

--- a/src/test/java/com/ifactory/press/db/solr/highlight/SolrUnifiedHighlighterTest.java
+++ b/src/test/java/com/ifactory/press/db/solr/highlight/SolrUnifiedHighlighterTest.java
@@ -28,21 +28,44 @@ public class SolrUnifiedHighlighterTest extends HeronSolrTest {
   public void testHighlightChapter5() throws SolrServerException, IOException {
     // searching for "gas" didn't work on the Safari site
     indexDocument ("ch5.txt");
-    assertSnippet ("gas", "Chapter 5\n Prospects and Evolutions of Electric-Powered Vehicles:<b>gas</b> What Technologies &lt; &amp; by 2015?");
+    assertSnippet (
+            "gas",
+            "450",
+            "Chapter 5\n Prospects and Evolutions of Electric-Powered Vehicles:<b>gas</b> What Technologies &lt; &amp; by 2015?"
+    );
   }
   
   @Test
-  public void testSnippetScoring() throws Exception {
+  public void testSnippetsSortedByScore() throws Exception {
     indexDocument ("daly-web-framework.txt");
-    assertSnippet ("who had fond memories", "Ruby's status as a next-generation scripting language inspired programmers <b>who</b> <b>had</b> <b>fond</b> <b>memories</b> of quick Perl projects but did not want to trade flexibility for readability.");
+    assertSnippet (
+            "who had fond memories",
+            "300",
+            "Ruby's status as a next-generation scripting language inspired programmers <b>who</b> <b>had</b> " +
+                    "<b>fond</b> <b>memories</b> of quick Perl projects but did not want to trade flexibility for readability."
+    );
+  }
+
+  @Test
+  public void testSnippetWithLargerFragSize() throws Exception {
+    indexDocument ("daly-web-framework.txt");
+    assertSnippet (
+            "who had fond memories",
+            "450",
+            "Its emphasis on \"convention over configuration\" was a breath of fresh air to developers " +
+                    "<b>who</b> <b>had</b> struggled with configuration-heavy Java frameworks such as Struts. " +
+                    "Ruby's status as a next-generation scripting language inspired programmers <b>who</b> <b>had</b> " +
+                    "<b>fond</b> <b>memories</b> of quick Perl projects but did not want to trade flexibility for readability."
+    );
   }
 
   // TODO - randomized testing -- search for phrases and/or words drawn from sentences and
   // expect those same sentences to be returned.
   
-  private void assertSnippet (String q, String expectedSnippet) throws SolrServerException, IOException {
+  private void assertSnippet (String q, String fragSize, String expectedSnippet) throws SolrServerException, IOException {
     SolrQuery query = new SolrQuery(q);
     query.setHighlight(true);
+    query.set("hl.fragsize", fragSize);
     query.set("hl.tag.pre", "<b>");
     query.set("hl.tag.ellipsis", "¦");
     query.set("f.text.hl.snippets", 3); // override value of 3 specified in solrconfig.xml

--- a/src/test/java/com/ifactory/press/db/solr/highlight/SolrUnifiedHighlighterTest.java
+++ b/src/test/java/com/ifactory/press/db/solr/highlight/SolrUnifiedHighlighterTest.java
@@ -16,7 +16,7 @@ import org.junit.Test;
 
 import com.ifactory.press.db.solr.HeronSolrTest;
 
-public class SolrPostingsHighlighterTest extends HeronSolrTest {
+public class SolrUnifiedHighlighterTest extends HeronSolrTest {
   
   @Before
   public void setup () throws SolrServerException, IOException {

--- a/src/test/java/com/ifactory/press/db/solr/highlight/UnifiedHighlighterTest.java
+++ b/src/test/java/com/ifactory/press/db/solr/highlight/UnifiedHighlighterTest.java
@@ -79,7 +79,7 @@ public class UnifiedHighlighterTest {
     IndexSearcher searcher = new IndexSearcher(reader);
 
     // retrieve highlights at query time 
-    UnifiedHighlighter highlighter = new UnifiedHighlighter(searcher, null);  // TODO (AG): pass in an IndexAnalyzer here, not null
+    UnifiedHighlighter highlighter = new UnifiedHighlighter(searcher, new SafariAnalyzer(true));
     Query query = new TermQuery(new Term("text", "gas"));
     TopDocs topDocs = searcher.search(query, 1);
     String highlights[] = highlighter.highlight("text", query, topDocs);

--- a/src/test/java/com/ifactory/press/db/solr/highlight/UnifiedHighlighterTest.java
+++ b/src/test/java/com/ifactory/press/db/solr/highlight/UnifiedHighlighterTest.java
@@ -6,21 +6,16 @@ import static org.apache.lucene.analysis.miscellaneous.WordDelimiterFilter.*;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.io.Reader;
 import java.text.ParseException;
-import java.util.regex.Pattern;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.lucene.analysis.Analyzer;
-import org.apache.lucene.analysis.CharFilter;
 import org.apache.lucene.analysis.TokenFilter;
 import org.apache.lucene.analysis.Tokenizer;
-import org.apache.lucene.analysis.charfilter.HTMLStripCharFilter;
 import org.apache.lucene.analysis.core.LowerCaseFilter;
 import org.apache.lucene.analysis.core.WhitespaceTokenizer;
 import org.apache.lucene.analysis.miscellaneous.RemoveDuplicatesTokenFilter;
 import org.apache.lucene.analysis.miscellaneous.WordDelimiterFilter;
-import org.apache.lucene.analysis.pattern.PatternReplaceCharFilter;
 import org.apache.lucene.analysis.synonym.SolrSynonymParser;
 import org.apache.lucene.analysis.synonym.SynonymFilter;
 import org.apache.lucene.analysis.synonym.SynonymMap;
@@ -39,13 +34,13 @@ import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.TopDocs;
-import org.apache.lucene.search.postingshighlight.PostingsHighlighter;
+import org.apache.lucene.search.uhighlight.UnifiedHighlighter;
 import org.apache.lucene.store.RAMDirectory;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-public class PostingsHighlighterTest {
+public class UnifiedHighlighterTest {
 
   private IndexWriter iw;
   
@@ -84,10 +79,10 @@ public class PostingsHighlighterTest {
     IndexSearcher searcher = new IndexSearcher(reader);
 
     // retrieve highlights at query time 
-    PostingsHighlighter highlighter = new PostingsHighlighter(100000);
+    UnifiedHighlighter highlighter = new UnifiedHighlighter(searcher, null);  // TODO (AG): pass in an IndexAnalyzer here, not null
     Query query = new TermQuery(new Term("text", "gas"));
     TopDocs topDocs = searcher.search(query, 1);
-    String highlights[] = highlighter.highlight("text", query, searcher, topDocs);
+    String highlights[] = highlighter.highlight("text", query, topDocs);
     assertEquals (1, highlights.length);
     assertNotNull ("PH returns null highlight", highlights[0]);
     assertTrue (highlights[0] + " \n does not contain <b>gas</b>", highlights[0].contains("<b>gas</b>"));

--- a/src/test/java/com/ifactory/press/db/solr/search/SafariQueryParserTest.java
+++ b/src/test/java/com/ifactory/press/db/solr/search/SafariQueryParserTest.java
@@ -24,16 +24,16 @@ public class SafariQueryParserTest extends SolrTest {
 
   @Test
   public void testPhraseFields () throws Exception {
-    assertParse (BQW(BQ(DMQ(TQ(A_T, "hey")))), "hey", B_T2);
-    assertParse (BQW(BQ(DMQ(B(PQ(B_T, "one", "two"), 2.0f)))), "\"one two\"", B_T2);
+    assertParse (BQ(DMQ(TQ(A_T, "hey"))), "hey", B_T2);
+    assertParse (BQ(DMQ(B(PQ(B_T, "one", "two"), 2.0f))), "\"one two\"", B_T2);
     assertParse (BQW(BQ(DMQ(TQ(A_T, "hey")), DMQ(B(PQ(B_T, "one", "two"), 2.0f)), TQ("c_t", "ho"))), "+hey +\"one two\" +c_t:ho", B_T2);
   }
   
   @Test
   public void testNoPhraseFields () throws Exception {
-    assertParse (BQW(BQ(DMQ(TQ(A_T, "hey")))), "hey", "");
+    assertParse (BQ(DMQ(TQ(A_T, "hey"))), "hey", "");
     assertParse (BQW(BQ(DMQ(TQ(A_T, "one")),DMQ(TQ(A_T, "two")))), "+one +two", "");
-    assertParse (BQW(BQ(DMQ(PQ(A_T, "one", "two")))), "\"one two\"", "");
+    assertParse (BQ(DMQ(PQ(A_T, "one", "two"))), "\"one two\"", "");
   }
   
   private TermQuery TQ(String f, String v) {
@@ -58,7 +58,6 @@ public class SafariQueryParserTest extends SolrTest {
   
   private BooleanQuery BQ(Query ... clauses) {
     BooleanQuery.Builder bqBuilder = new BooleanQuery.Builder();
-    bqBuilder.setDisableCoord(false).setMinimumNumberShouldMatch(0);
 
     for (Query q : clauses) {
       bqBuilder.add(q, Occur.MUST);
@@ -73,7 +72,6 @@ public class SafariQueryParserTest extends SolrTest {
    */
   private BooleanQuery BQW(BooleanQuery bq) {
     BooleanQuery.Builder bqBuilder = new BooleanQuery.Builder();
-    bqBuilder.setDisableCoord(true).setMinimumNumberShouldMatch(0);
     bqBuilder.add(bq, Occur.MUST);
     return bqBuilder.build();
   }


### PR DESCRIPTION
The CHANGELOG outlines the changes with Solr ticket numbers, commit history separates each of these changes.

The only change worth noting is that PostingsHighlighter (what we used) was removed in favor of UnifiedHighlighter, which should work exactly the same. However, looks like UnifiedHighlighter will try to combine multiple sentences (for extra context) into one highlighted snippet depending on the `fragsize` option. The old PostingsHighlighter ignored `fragsize` and always split sentences into their own snippets. I added an extra test to _highlight_ this change (pun intended).

Solr plugin finally up to date, wooooo!
![donesuccess](https://user-images.githubusercontent.com/6943384/56137852-abc92d00-5f63-11e9-9383-8f529bcfee9e.gif)
