### PR TITLE
MultiSuggester respects InfixLookup's highlight option

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>ifpress</groupId>
   <artifactId>ifpress-solr-plugin</artifactId>
-  <version>1.3.11-SNAPSHOT</version>
+  <version>1.4.1</version>
   <name>ifpress solr plugin</name>
   <description>Contains plugins to be installed in the solr server</description>
   <dependencies>

--- a/solr/collection1/conf/solrconfig.xml
+++ b/solr/collection1/conf/solrconfig.xml
@@ -1049,7 +1049,6 @@
       <float name="threshold">0.0</float>
       <!-- true => NPE now that we have NRT support??.  For production, schedule a rebuild nightly instead -->
       <str name="buildOnCommit">false</str>
-      <bool name="highlight">false</bool>
       <lst name="fields">
         <lst name="field">
           <str name="name">fulltext_t</str>


### PR DESCRIPTION
Solr's Suggester class's `getSuggestions()` completely ignores LookupResult's `highlightKey`, which has the highlighted suggestions. Our MultiSuggester class is a subclass of Suggester, so instead of using Suggester's `getSuggestions()`, this will use a custom method that is a copy of `getSuggestions()` but with modification to respect highlightKey if it exists.

I also changed the solrconfig and tests to use highlighting. Suggest highlighting was completely turned off, which is why I missed this when upgrading.