### PR TITLE
v1.6.1 MultiSuggester respects InfixLookup's highlight option

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>ifpress</groupId>
   <artifactId>ifpress-solr-plugin</artifactId>
-  <version>1.6.0</version>
+  <version>1.6.1</version>
   <name>ifpress solr plugin</name>
   <description>Contains plugins to be installed in the solr server</description>
   <dependencies>

--- a/solr/collection1/conf/solrconfig.xml
+++ b/solr/collection1/conf/solrconfig.xml
@@ -1050,7 +1050,6 @@
       <float name="threshold">0.0</float>
       <!-- true => NPE now that we have NRT support??.  For production, schedule a rebuild nightly instead -->
       <str name="buildOnCommit">false</str>
-      <bool name="highlight">false</bool>
       <lst name="fields">
         <lst name="field">
           <str name="name">fulltext_t</str>


### PR DESCRIPTION
Apply the same patch from 1.4.1 and 1.5.1