### PR TITLE
V1.5.3 | Add option to exclude docs from suggestions based on specific formats

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>ifpress</groupId>
   <artifactId>ifpress-solr-plugin</artifactId>
-  <version>1.5.2</version>
+  <version>1.5.3</version>
   <name>ifpress solr plugin</name>
   <description>Contains plugins to be installed in the solr server</description>
   <dependencies>

--- a/solr/collection1/conf/schema.xml
+++ b/solr/collection1/conf/schema.xml
@@ -322,6 +322,7 @@
     <field name="directory_b" type="boolean" indexed="true" stored="true" />
     <field name="binary" type="binary" indexed="false" stored="true" />
     <field name="title_t" type="text" indexed="true" stored="true" />
+    <field name="format" type="text" indexed="true" stored="true"/>
 
     <!-- text content that is searched by default; we store it so solr can 
       do highlighting -->

--- a/solr/collection1/conf/solrconfig.xml
+++ b/solr/collection1/conf/solrconfig.xml
@@ -1049,6 +1049,8 @@
       <float name="threshold">0.0</float>
       <!-- true => NPE now that we have NRT support??.  For production, schedule a rebuild nightly instead -->
       <str name="buildOnCommit">false</str>
+      <str name="excludeFormat">collection</str>
+      <str name="excludeFormat">test-format</str>
       <lst name="fields">
         <lst name="field">
           <str name="name">fulltext_t</str>

--- a/src/main/java/com/ifactory/press/db/solr/spelling/suggest/MultiSuggester.java
+++ b/src/main/java/com/ifactory/press/db/solr/spelling/suggest/MultiSuggester.java
@@ -169,7 +169,7 @@ public class MultiSuggester extends Suggester {
     this.shouldExcludeFormats = this.excludeFormats != null && !this.excludeFormats.isEmpty();
 
     if(this.shouldExcludeFormats) {
-      LOG.info(String.format("Excluding docs from suggestions that have the one of the formats: %s", excludeFormats.toString()));
+      LOG.info(String.format("Excluding docs from suggestions that have one of the formats: %s", excludeFormats.toString()));
     }
 
     // Workaround for SOLR-6246 (lock exception on core reload): close
@@ -291,7 +291,7 @@ public class MultiSuggester extends Suggester {
         if(this.shouldExcludeFormats) {
           IndexableField format = doc.getField("format");
           if (format != null && this.excludeFormats.contains(format.stringValue())) {
-            LOG.info(String.format("Skipping build suggestion for doc with a format of: %s", format.stringValue()));
+            LOG.info(String.format("Skipping BUILD suggestion for doc with a format of: %s", format.stringValue()));
           } else {
             addRaw(fld, value);
           }
@@ -352,7 +352,7 @@ public class MultiSuggester extends Suggester {
 
     SolrInputField format = doc.getField("format");
     if (format != null && this.excludeFormats.contains(format.getValue().toString())) {
-      LOG.info(String.format("Skipping add suggestion for doc with a format of: %s", format.getValue().toString()));
+      LOG.info(String.format("Skipping ADD suggestion for doc with a format of: %s", format.getValue().toString()));
       return;
     }
 


### PR DESCRIPTION
Using the new `excludeFormat` field in the suggestion block of the solrconfig.xml, you can specify multiple formats for which to exclude docs from suggestions.

Note: this excludes the docs at build time (not suggestion query time), so these docs are never added to the suggest index. This works when the docs are first added to the index and when a complete suggest rebuild is kicked off.