### PR TITLE
V1.5.4 Suggest build only scans documents once for multiple fields

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>ifpress</groupId>
   <artifactId>ifpress-solr-plugin</artifactId>
-  <version>1.5.3</version>
+  <version>1.5.4</version>
   <name>ifpress solr plugin</name>
   <description>Contains plugins to be installed in the solr server</description>
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -74,8 +74,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>2.0.2</version>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
           <encoding>UTF-8</encoding>
         </configuration>
       </plugin>

--- a/src/main/java/com/ifactory/press/db/solr/spelling/suggest/MultiSuggester.java
+++ b/src/main/java/com/ifactory/press/db/solr/spelling/suggest/MultiSuggester.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.text.BreakIterator;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.Token;
@@ -145,14 +146,19 @@ public class MultiSuggester extends Suggester {
   // range. WEIGHT_SCALE should be greater than the number of documents
   private static final int WEIGHT_SCALE = 10000000;
   private static final int DEFAULT_MAX_SUGGESTION_LENGTH = 80;
+  private static final int BUILD_LOGGING_THRESHOLD = 100000;
+  private static final int BUILD_COMMIT_THRESHOLD = 10000;
   private static final String EXCLUDE_FORMAT_KEY = "excludeFormat";
 
   private static final Logger LOG = LoggerFactory.getLogger(MultiSuggester.class);
 
   private WeightedField[] fields;
+  private List<WeightedField> storedFields;
+  private List<WeightedField> termFields;
   private int maxSuggestionLength;
   private List<String> excludeFormats;
   private boolean shouldExcludeFormats;
+  private Set<String> addedStoredValues;
 
   // use a synchronized Multimap - there may be one with the same name for each
   // core
@@ -209,6 +215,8 @@ public class MultiSuggester extends Suggester {
 
   private void initWeights(NamedList fieldConfigs, SolrCore coreParam) {
     fields = new WeightedField[fieldConfigs.size()];
+    storedFields = new ArrayList<>();
+    termFields = new ArrayList<>();
     for (int ifield = 0; ifield < fieldConfigs.size(); ifield++) {
       NamedList fieldConfig = (NamedList) fieldConfigs.getVal(ifield);
       String fieldName = (String) fieldConfig.get("name");
@@ -230,6 +238,7 @@ public class MultiSuggester extends Suggester {
       }
       String analyzerFieldTypeName = (String) fieldConfig.get("analyzerFieldType");
       Analyzer fieldAnalyzer;
+      WeightedField field;
 
       boolean useStoredField = analyzerFieldTypeName != null;
       if (useStoredField) {
@@ -239,11 +248,15 @@ public class MultiSuggester extends Suggester {
         } else {
           fieldAnalyzer = coreParam.getLatestSchema().getFieldTypeByName(analyzerFieldTypeName).getIndexAnalyzer();
         }
+        field = new WeightedField(fieldName, weight, minFreq, maxFreq, fieldAnalyzer, useStoredField, filterDuplicates);
+        storedFields.add(field);
       } else {
         // Use the existing term values as analyzed by the field
         fieldAnalyzer = coreParam.getLatestSchema().getFieldType(fieldName).getIndexAnalyzer();
+        field = new WeightedField(fieldName, weight, minFreq, maxFreq, fieldAnalyzer, useStoredField, filterDuplicates);
+        termFields.add(field);
       }
-      fields[ifield] = new WeightedField(fieldName, weight, minFreq, maxFreq, fieldAnalyzer, useStoredField, filterDuplicates);
+      fields[ifield] = field;
     }
     Arrays.sort(fields);
   }
@@ -256,18 +269,17 @@ public class MultiSuggester extends Suggester {
 
     SafariInfixSuggester ais = (SafariInfixSuggester) lookup;
     ais.clear();
-    
+
+    // index all stored fields with one pass through the index
+    buildFromStoredFields(storedFields, searcher);
+
     // index all the terms-based fields using dictionaries
-    for (WeightedField fld : fields) {
-      if (fld.useStoredField) {
-        buildFromStoredField(fld, searcher);
-      } else {
-        // TODO: refactor b/c we're not really using the MultiDictionary's multiple dictionary capability any more
-        dictionary = new MultiDictionary();
-        buildFromTerms(fld);
-        ais.add(dictionary);
-        ais.refresh();
-      }
+    for (WeightedField termField : termFields) {
+      // TODO: refactor b/c we're not really using the MultiDictionary's multiple dictionary capability any more
+      dictionary = new MultiDictionary();
+      buildFromTerms(termField);
+      ais.add(dictionary);
+      ais.refresh();
     }
 
     long endTime = System.currentTimeMillis();
@@ -275,18 +287,14 @@ public class MultiSuggester extends Suggester {
     LOG.info(String.format("%s suggestion index built: %d suggestions. Total time: %d seconds.", name, ais.getCount(), totalBuildTime));
   }
 
-  private void buildFromStoredField(WeightedField fld, SolrIndexSearcher searcher) throws IOException {
-    if (fld.fieldAnalyzer != null) {
-      throw new IllegalStateException("not supported: analyzing stored fields");
-    }
-    LOG.info(String.format("build suggestions from values for: %s (%d)", fld.fieldName, fld.weight));
+  private void buildFromStoredFields(List<WeightedField> flds, SolrIndexSearcher searcher) throws IOException {
+    LOG.info(String.format("%s Suggest BUILD for stored fields: %s", name, flds));
     long startTime = System.currentTimeMillis();
     long endTime;
     long elapsedSeconds;
     int lastCommitCount = 0;
-    Set<String> fieldsToLoad = new HashSet<String>();
-    Set<String> addedValues = new HashSet<String>();
-    fieldsToLoad.add(fld.fieldName);
+    addedStoredValues = new HashSet<>();
+    Set<String> fieldsToLoad = flds.stream().map(fld -> fld.fieldName).collect(Collectors.toSet());
     // Load the format field so we can filter out docs by specific formats
     if(this.shouldExcludeFormats) {
       fieldsToLoad.add("format");
@@ -295,42 +303,53 @@ public class MultiSuggester extends Suggester {
     int addCount = 0;
     int excludedFormatDocCount = 0;
     for (int idoc = 0; idoc < maxDoc; ++idoc) {
-      // TODO: exclude deleted documents
       Document doc = reader.document(idoc, fieldsToLoad);
-      String value = doc.get(fld.fieldName);
-      if (value != null && !value.isEmpty()) {
-        if(this.shouldExcludeFormats) {
-          IndexableField format = doc.getField("format");
-          if (format != null && this.excludeFormats.contains(format.stringValue())) {
-            excludedFormatDocCount++;
-          } else if (addedValues.add(value)) {
-            addCount++;
-            addRaw(fld, value);
-          }
-        } else if(addedValues.add(value)) {
-          addCount++;
-          addRaw(fld, value);
+      if(this.shouldExcludeFormats) {
+        IndexableField format = doc.getField("format");
+        if (format != null && this.excludeFormats.contains(format.stringValue())) {
+          excludedFormatDocCount++;
+        } else {
+          addCount += addSuggestionValues(doc, flds);
         }
+      } else {
+        addCount += addSuggestionValues(doc, flds);
       }
-      if (idoc % 50000 == 49999) {
+      // Progress logging
+      if (idoc % BUILD_LOGGING_THRESHOLD == BUILD_LOGGING_THRESHOLD - 1) {
         endTime = System.currentTimeMillis();
         elapsedSeconds = (endTime - startTime) / 1000;
-        LOG.info(String.format("%s Suggest BUILD for field %s - Docs added: %d", name, fld.fieldName, addCount));
+        LOG.info(String.format("%s BUILD for fields %s - Docs added: %d", name, flds, addCount));
         LOG.info(String.format("Docs scanned: %d / %d. %d%% Completed. Time spent: %d seconds.\n", idoc, maxDoc, Math.round(((double)idoc/maxDoc)*100), elapsedSeconds));
       }
-      if (addCount % 10000 == 9999 && addCount != lastCommitCount) {
-        LOG.info(String.format("%s Suggest BUILD COMMIT for field %s. Docs added: %d\n", name, fld.fieldName, addCount));
-        commit(searcher);
+      // Commit if reached commit threshold and have added more docs since last commit
+      if (addCount % BUILD_COMMIT_THRESHOLD == BUILD_COMMIT_THRESHOLD - 1 && addCount != lastCommitCount) {
+        LOG.info(String.format("%s BUILD COMMIT - Docs added: %s\n", name, flds));
         lastCommitCount = addCount;
+        commit(searcher);
       }
     }
-    LOG.info(String.format("%s Suggest BUILD for field %s - Committing remaining docs. Docs added: %d\n", name, fld.fieldName, addCount));
     commit(searcher);
     endTime = System.currentTimeMillis();
     elapsedSeconds = (endTime-startTime) / 1000;
-    LOG.info(String.format("%s Suggest BUILD COMPLETED for field %s. Build time: %d seconds.", name, fld.fieldName, elapsedSeconds));
+    LOG.info(String.format("%s BUILD COMPLETED for fields %s. Build time: %d seconds.", name, flds, elapsedSeconds));
     LOG.info(String.format("Total docs added: %d. Total docs excluded due to format: %d.\n\n\n", addCount, excludedFormatDocCount));
   }
+
+    // Iterates through all storedFields in the doc, adding their values if they are not empty and not already added.
+    // Returns the number of values added.
+    private int addSuggestionValues(Document doc, List<WeightedField> storedFields) throws IOException {
+      int valuesAdded = 0;
+      for(WeightedField fld : storedFields) {
+        String fldName = fld.fieldName;
+        String value = doc.get(fldName);
+        // Only add if value is not null, empty, or already added to suggestions.
+        if (value != null && !value.isEmpty() && addedStoredValues.add(value)) {
+          valuesAdded++;
+          addRaw(fld, value);
+        }
+      }
+      return valuesAdded;
+    }
 
   private void buildFromTerms(WeightedField fld) throws IOException {
     HighFrequencyDictionary hfd = new HighFrequencyDictionary(reader, fld.fieldName, fld.minFreq);


### PR DESCRIPTION
Improvements on to how suggestions on stored fields are built in MultiSuggester:

1. Builds only scan doc set once to build suggestions for multiple fields
2. Filters duplication and empty values at build time
3. Much better progress logging: a running total of the suggestions added, percentage of the doc set scanned, running total of time spent, which suggester and fields are being used.

Bumped the dev's Java version to 8 so that I can use Streaming. Our Solr servers have already been running on Java 8.